### PR TITLE
docs(cioos.md): expand documentation with detailed guide on CIOOS and account registration steps

### DIFF
--- a/docs/data-repository-documentation/cioos.md
+++ b/docs/data-repository-documentation/cioos.md
@@ -1,1 +1,24 @@
 # CIOOS
+
+The Canadian Integrated Ocean Observing System ([CIOOS](https://www.cioos.ca/)) is a national network of regional associations that work together to collect, manage, and share ocean data.
+
+> CIOOS engages locally, connects regionally, and coordinates nationally to elevate Canada’s ocean monitoring to the global stage. These partnerships generate information and facilitate place-based solutions to advance our understanding of the ocean. With CIOOS, users can now discover, access, and visualize high-quality data through our online platform. By navigating these vast waters together, CIOOS helps prepare for Canada’s future by unlocking the true potential of our ocean, coasts, and waterways.
+
+## Getting started
+
+This guide will help you get started with submitting your data to CIOOS. If you have any questions or need help, please contact the TCA Data Management Accelerator team.
+
+### Register for an account
+
+Go to the [CIOOS Metadata Entry Tool](https://cioos-siooc.github.io/metadata-entry-form/#/en/region-select) to create an account. At this time, you will need a Google account to register. If you do not have a Google account, you can create one using your existing email address by following these steps:
+
+1. Click Sign in on the form.
+2. Click "Use another account".
+3. Click "Create account".
+4. Fill in your name (not important).
+5. Fill in your date of birth and sex (not important).
+6. Click "Use your existing email".
+7. Write your desired email.
+8. It will send you a code to your email.
+9. Confirm account.
+


### PR DESCRIPTION
This pull request adds comprehensive documentation for the Canadian Integrated Ocean Observing System (CIOOS), providing background information and a step-by-step guide for registering an account to submit data. The new content aims to help users understand CIOOS and get started with the metadata submission process.

I have added this because it might not be obvious to get started if someone do not use a Google account.